### PR TITLE
Fix password file to actually be used

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     user: postgres
     environment:
       POSTGRES_USER: gordonuser
-      POSTGRES_DB_PASSWORD_FILE: /run/secrets/postgres_password
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       POSTGRES_DB: atsea
     ports:
       - "5432:5432" 


### PR DESCRIPTION
According to the documentation, this is [`POSTGRES_PASSWORD_FILE`](https://github.com/docker-library/docs/tree/2b3cbc311670957d144f8c7004ba04b5d563491a/postgres#docker-secrets).  Otherwise postgres will be set with no password and just allow any connection with the correct username regardless of a supplied password.  You can verify it by running postgres with the current yaml and see this in the logs:

```console
****************************************************
WARNING: No password has been set for the database.
         This will allow anyone with access to the
         Postgres port to access your database. In
         Docker's default configuration, this is
         effectively any other container on the same
         system.

         Use "-e POSTGRES_PASSWORD=password" to set
         it in "docker run".
****************************************************
```

You'll also want to update the blog post on Docker Blog that copies this part of the file: https://blog.docker.com/2017/07/securing-atsea-app-docker-secrets/.